### PR TITLE
fix: remove overflow:hidden from html/body to allow mobile scroll

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,5 @@
 html, body {
     margin: 0;
     padding: 0;
-    overflow: hidden;
-    height: 100%;
+    min-height: 100%;
 }


### PR DESCRIPTION
Web version had no scroll container unlike desktop (which uses .desktop-layout),
so overflow:hidden on html/body completely blocked scrolling on mobile.
Changed to min-height:100% — desktop scroll behavior is unaffected since
App.desktop.css already manages scroll within .desktop-content.

https://claude.ai/code/session_01QHbEFdPJgK8exv4GZB9dJA