### PR TITLE
fix: resolve mobile horizontal scroll and iOS textarea zoom

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,7 +12,8 @@
     font-display: swap;
 }
 
-* {
+*, *::before, *::after {
+    box-sizing: border-box;
     font-family: 'Pretendard', sans-serif;
 }
 
@@ -20,4 +21,5 @@ html, body {
     margin: 0;
     padding: 0;
     min-height: 100%;
+    overflow-x: hidden;
 }

--- a/frontend/src/pages/checker.css
+++ b/frontend/src/pages/checker.css
@@ -261,7 +261,7 @@
 
   .checker-textarea {
     min-height: 160px;
-    font-size: 14px;
+    font-size: 16px;
   }
 
   .checker-btn-row {


### PR DESCRIPTION
- Add box-sizing:border-box globally — .checker-wrap had width:100% + padding
  without border-box, causing 32px overflow and horizontal scroll
- Add overflow-x:hidden on html/body as a safety net
- Set textarea font-size to 16px on mobile — iOS Safari zooms in on any
  input/textarea with font-size < 16px on focus

https://claude.ai/code/session_01QHbEFdPJgK8exv4GZB9dJA